### PR TITLE
Add curl in apt-get

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt-get install -y htop iotop iftop bwm-ng screen git python-dev python-pip python3-dev python3-pip tree psmisc dosfstools parted bash-completion fswebcam v4l-utils network-manager usbutils nano stress-ng
+apt-get install -y htop iotop iftop bwm-ng screen git python-dev python-pip python3-dev python3-pip tree psmisc dosfstools parted bash-completion fswebcam v4l-utils network-manager usbutils nano stress-ng curl
 
 pip3 install -U pip
 


### PR DESCRIPTION
Since waggle_epoch services uses ``` curl``` it should be added in ```install_dependencies.sh```.