### PR TITLE
Staged Boot Process

### DIFF
--- a/systemd/rabbitmq-server.service
+++ b/systemd/rabbitmq-server.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=RabbitMQ broker
+After=network.target epmd@0.0.0.0.socket
+Wants=network.target epmd@0.0.0.0.socket
+
+[Service]
+Type=notify
+User=rabbitmq
+Group=rabbitmq
+NotifyAccess=all
+TimeoutStartSec=3600
+WorkingDirectory=/var/lib/rabbitmq
+ExecStart=/usr/lib/rabbitmq/bin/rabbitmq-server
+ExecStop=/usr/lib/rabbitmq/bin/rabbitmqctl stop
+
+[Install]
+WantedBy=waggle-platform.target

--- a/systemd/waggle-configure-static-iface.service
+++ b/systemd/waggle-configure-static-iface.service
@@ -7,4 +7,4 @@ Type=oneshot
 ExecStart=/usr/lib/waggle/core/scripts/configure-static-iface.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=waggle-core.target

--- a/systemd/waggle-configure-static-iface.service
+++ b/systemd/waggle-configure-static-iface.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Uses the MAC address to setup the static enx* network interface.
-After=waggle-core.target
 Before=networking.service
 
 [Service]
@@ -8,4 +7,4 @@ Type=oneshot
 ExecStart=/usr/lib/waggle/core/scripts/configure-static-iface.sh
 
 [Install]
-WantedBy=waggle-core.target
+WantedBy=networking.target

--- a/systemd/waggle-configure-static-iface.service
+++ b/systemd/waggle-configure-static-iface.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Uses the MAC address to setup the static enx* network interface.
+After=waggle-core.target
 Before=networking.service
 
 [Service]

--- a/systemd/waggle-epoch.service
+++ b/systemd/waggle-epoch.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Maintains the date and time on the node.
-After=network.target
+After=waggle-core.target network.target
 
 [Service]
 ExecStart=/usr/lib/waggle/core/scripts/waggle_epoch.sh

--- a/systemd/waggle-epoch.service
+++ b/systemd/waggle-epoch.service
@@ -9,4 +9,4 @@ Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=waggle-core.target

--- a/systemd/waggle-heartbeat.service
+++ b/systemd/waggle-heartbeat.service
@@ -9,4 +9,4 @@ Restart=always
 RestartSec=5
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=waggle-core.target

--- a/systemd/waggle-heartbeat.service
+++ b/systemd/waggle-heartbeat.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Triggers Wagman heartbeat line.
+After=waggle-core.target
 
 [Service]
 WorkingDirectory=/usr/lib/waggle/core/scripts

--- a/systemd/waggle-init.service
+++ b/systemd/waggle-init.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Initializes Waggle system.
 After=waggle-core.target
+Before=waggle-platform.target
 
 [Service]
 Type=oneshot
@@ -9,3 +10,4 @@ ExecStart=/usr/lib/waggle/core/scripts/waggle_init.sh force
 
 [Install]
 WantedBy=waggle-core.target
+RequiredBy=waggle-platform.target

--- a/systemd/waggle-init.service
+++ b/systemd/waggle-init.service
@@ -6,4 +6,4 @@ WorkingDirectory=/usr/lib/waggle/core/
 ExecStart=/usr/lib/waggle/core/scripts/waggle_init.sh force
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=waggle-core.target

--- a/systemd/waggle-init.service
+++ b/systemd/waggle-init.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Initializes Waggle system.
+After=waggle-core.target
 
 [Service]
 WorkingDirectory=/usr/lib/waggle/core/

--- a/systemd/waggle-init.service
+++ b/systemd/waggle-init.service
@@ -3,6 +3,7 @@ Description=Initializes Waggle system.
 After=waggle-core.target
 
 [Service]
+Type=oneshot
 WorkingDirectory=/usr/lib/waggle/core/
 ExecStart=/usr/lib/waggle/core/scripts/waggle_init.sh force
 


### PR DESCRIPTION
Splits the boot process into core and platform services. The platform services aren't started until waggle-init completes.